### PR TITLE
Docs: Fix link

### DIFF
--- a/tutorial.cxx
+++ b/tutorial.cxx
@@ -265,7 +265,7 @@ memory_specs_t fetch_memory_specs() {
 ///
 /// On x86, when SSE4.2 is available, the `crc32` instruction can be used. Both `CRC R32, R/M32` and `CRC32 R32, R/M64`
 /// have a latency of 3 cycles on practically all Intel and AMD CPUs,  and can execute only on one port.
-/// Check out @b https://uops.info/table for more details.
+/// Check out @b https://uops.info/table.html for more details.
 inline std::uint32_t crc32_hash(std::uint32_t x) noexcept {
     return x * 2654435761u;
 #if defined(__SSE4_2__)


### PR DESCRIPTION
I fixed the typo in the link. Also, I resolved the git diff message: "No newline at the end of file". I checked, and a 0a byte (newline) now appears at the end, as per old-school convention, I guess.