### PR TITLE
Improve matrix multiplication for AVX512

### DIFF
--- a/less_slow.cpp
+++ b/less_slow.cpp
@@ -854,26 +854,22 @@ void f32_matrix_multiplication_4x4_loop_avx512_kernel(float a[4][4], float b[4][
 
     __m512 a_vec_1 = _mm512_permute_ps(a_mat, 0x0);
     __m512 b_vec_1 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
-    __m512 c_row_1 = _mm512_mul_ps(a_vec_1, b_vec_1);
+    __m512 c_vec = _mm512_mul_ps(a_vec_1, b_vec_1);
 
     __m512 a_vec_2 = _mm512_permute_ps(a_mat, 0x55);
     b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
     __m512 b_vec_2 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
-    __m512 c_row_2 = _mm512_mul_ps(a_vec_2, b_vec_2);
+    c_vec = _mm512_fmadd_ps(a_vec_2, b_vec_2, c_vec);
 
     __m512 a_vec_3 = _mm512_permute_ps(a_mat, 0xAA);
     b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
     __m512 b_vec_3 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
-    __m512 c_row_3 = _mm512_mul_ps(a_vec_3, b_vec_3);
+    c_vec = _mm512_fmadd_ps(a_vec_3, b_vec_3, c_vec);
 
     __m512 a_vec_4 = _mm512_permute_ps(a_mat, 0xFF);
     b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
     __m512 b_vec_4 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
-    __m512 c_row_4 = _mm512_mul_ps(a_vec_4, b_vec_4);
-
-    __m512 c_row_12 = _mm512_add_ps(c_row_1, c_row_2);
-    __m512 c_row_34 = _mm512_add_ps(c_row_3, c_row_4);
-    __m512 c_vec = _mm512_add_ps(c_row_12, c_row_34);
+    c_vec = _mm512_fmadd_ps(a_vec_4, b_vec_4, c_vec);
 
     _mm512_storeu_ps(&c[0][0], c_vec);
 }

--- a/less_slow.cpp
+++ b/less_slow.cpp
@@ -848,85 +848,34 @@ BENCHMARK(f32_matrix_multiplication_4x4_loop_sse41);
 #pragma clang attribute push(__attribute__((target("avx2,avx512f,avx512bw,avx512vl,bmi2"))), apply_to = function)
 #endif
 
-inline __m512 mm512_shift_add(__m512 v, int shift_w) {
-    return _mm512_castsi512_ps(
-        _mm512_alignr_epi64(
-            _mm512_castps_si512(v), 
-            _mm512_castps_si512(v),
-            shift_w)
-    );
-}
-
 void f32_matrix_multiplication_4x4_loop_avx512_kernel(float a[4][4], float b[4][4], float c[4][4]) {
     __m512 a_mat = _mm512_loadu_ps(&a[0][0]);
     __m512 b_mat = _mm512_loadu_ps(&b[0][0]);
 
-    __m512i trans_perm = _mm512_setr_epi32( //
-        0, 4, 8, 12,                        //
-        1, 5, 9, 13,                        //
-        2, 6, 10, 14,                       //
-        3, 7, 11, 15                        //
-    );
+    __m512 a_vec_1 = _mm512_permute_ps(a_mat, 0x0);
+    __m512 b_vec_1 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
+    __m512 c_row_1 = _mm512_mul_ps(a_vec_1, b_vec_1);
 
-    // Begin calculatation for the First C Row
-    __m512 a_row_1_broad = _mm512_broadcast_f32x4(_mm512_castps512_ps128(a_mat));
-    __m512 a_row_1_broad_trans = _mm512_permutexvar_ps(trans_perm, a_row_1_broad);
-    __m512 c_row_1 = _mm512_mul_ps(a_row_1_broad_trans, b_mat);
+    __m512 a_vec_2 = _mm512_permute_ps(a_mat, 0x55);
+    b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
+    __m512 b_vec_2 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
+    __m512 c_row_2 = _mm512_mul_ps(a_vec_2, b_vec_2);
 
-    // Perform two shift-add operations to comput first C row
-    __m512 c_row_1_rot = mm512_shift_add(c_row_1, 0x4);
-    c_row_1 = _mm512_add_ps(c_row_1, c_row_1_rot);
-    c_row_1_rot = mm512_shift_add(c_row_1, 0x2);
+    __m512 a_vec_3 = _mm512_permute_ps(a_mat, 0xAA);
+    b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
+    __m512 b_vec_3 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
+    __m512 c_row_3 = _mm512_mul_ps(a_vec_3, b_vec_3);
 
-    // This vector will hold the accumulated rows for the result C matrix
-    c_row_1 = _mm512_add_ps(c_row_1, c_row_1_rot);
+    __m512 a_vec_4 = _mm512_permute_ps(a_mat, 0xFF);
+    b_mat = _mm512_castsi512_ps(_mm512_alignr_epi64(_mm512_castps_si512(b_mat), _mm512_castps_si512(b_mat), 0x2));
+    __m512 b_vec_4 = _mm512_broadcast_f32x4(_mm512_castps512_ps128(b_mat));
+    __m512 c_row_4 = _mm512_mul_ps(a_vec_4, b_vec_4);
 
-    // Begin calculation for the Second C Row
-    a_mat = mm512_shift_add(a_mat, 0x2);
-    __m512 a_row_2_broad = _mm512_broadcast_f32x4(_mm512_castps512_ps128(a_mat));
-    __m512 a_row_2_broad_trans = _mm512_permutexvar_ps(trans_perm, a_row_2_broad);
-    __m512 c_row_2 = _mm512_mul_ps(a_row_2_broad_trans, b_mat);
+    __m512 c_row_12 = _mm512_add_ps(c_row_1, c_row_2);
+    __m512 c_row_34 = _mm512_add_ps(c_row_3, c_row_4);
+    __m512 c_vec = _mm512_add_ps(c_row_12, c_row_34);
 
-    // Perform two shift-add operations to compute second C row
-    __m512 c_row_2_rot = mm512_shift_add(a_mat, 0x4);
-    c_row_2 = _mm512_add_ps(c_row_2, c_row_2_rot);
-    c_row_2_rot = mm512_shift_add(c_row_2, 0x2);
-    c_row_2 = _mm512_add_ps(c_row_2, c_row_2_rot);
-
-    // Blend lanes 4 to 7 of `c_row_2` into resulting vector
-    c_row_1 = _mm512_mask_blend_ps(0xF0, c_row_1, c_row_2);
-
-    // Begin calculation for Third C Row
-    a_mat = mm512_shift_add(a_mat, 0x2);
-    __m512 a_row_3_broad = _mm512_broadcast_f32x4(_mm512_castps512_ps128(a_mat));
-    __m512 a_row_3_broad_trans = _mm512_permutexvar_ps(trans_perm, a_row_3_broad);
-    __m512 c_row_3 = _mm512_mul_ps(a_row_3_broad_trans, b_mat);
-
-    // Perform two shift-add operations to compute third C row
-    __m512 c_row_3_rot = mm512_shift_add(c_row_3, 0x4);
-    c_row_3 = _mm512_add_ps(c_row_3, c_row_3_rot);
-    c_row_3_rot = mm512_shift_add(c_row_3, 0x2);
-    c_row_3 = _mm512_add_ps(c_row_3, c_row_3_rot);
-
-    // Blend lanes 8 to 11 of `c_row_3` into resulting vector
-    c_row_1 = _mm512_mask_blend_ps(0xF00, c_row_1, c_row_3);
-
-    // Begin calculation for Fourth C Row
-    a_mat = mm512_shift_add(a_mat, 0x2);
-    __m512 a_row_4_broad = _mm512_broadcast_f32x4(_mm512_castps512_ps128(a_mat));
-    __m512 a_row_4_broad_trans = _mm512_permutexvar_ps(trans_perm, a_row_4_broad);
-    __m512 c_row_4 = _mm512_mul_ps(a_row_4_broad_trans, b_mat);
-
-    // Perform two shift-add operations to compute fourth C row
-    __m512 c_row_4_rot = mm512_shift_add(c_row_4, 0x4);
-    c_row_4 = _mm512_add_ps(c_row_4, c_row_4_rot);
-    c_row_4_rot = mm512_shift_add(c_row_4, 0x2);
-    c_row_4 = _mm512_add_ps(c_row_4, c_row_4_rot);
-
-    // Blend the last 12 to 15 lanes of `c_row_4` into resulting vector
-    c_row_1 = _mm512_mask_blend_ps(0xF000, c_row_1, c_row_4);
-
-    _mm512_storeu_ps(&c[0][0], c_row_1);
+    _mm512_storeu_ps(&c[0][0], c_vec);
 }
 
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
I recently found a better and simpler way to perform multiplication. Benchmarks show 2.3 ns on my PC compared to over 4 ns previously.

It turns out that the art of SIMD lies in trusting that it was developed by smart people, and for routine algebra, it’s often better to check if there’s a faster and more concise way to achieve the same result.

Also, it turns out that the compiler can be effective, but not always. Check this out: https://godbolt.org/z/d4nM6q84K. There are three iterations of matrix multiplication.

Initially, I used `_mm512_setr_epi32` (sequence instruction) and `_mm512_permutexvar_ps`, which has a latency of 3. Then, I replaced both with `_mm512_permute_ps`, which has a latency of 1, but saw no improvements in the benchmark. It's obvious when looking at the assembly – the generated code is identical. The optimizer did its job well—actually, only Clang did. GCC fails to optimize it properly. This puzzles me, though, because I compiled it with GCC and see no difference.

However, in another iteration, I used `fmadd` (Latency 4) instead of `mul` (Latency 4) and the excessive `add` (Latency 4). This time, the assembly code is different! Performance seems to be slightly better. Apparently, the compiler didn’t optimize that case.

I will write a random test to perform a cross-check with a non-SIMD looped matrix multiplication and verify correctness tomorrow. However, it works correctly on a specific `std::iota`-like example.