### PR TITLE
Fix docs in README about CMAKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are familiar with C++ and want to go through code and measurements as you
 ```sh
 git clone https://github.com/ashvardanian/LessSlow.cpp.git  # Clone the repository
 cd LessSlow.cpp                                             # Change the directory
-cmake -B build_release                                      # Generate the build files
+cmake -B build_release -DCMAKE_BUILD_TYPE=Release           # Generate the build files
 cmake --build build_release --config Release                # Build the project
 build_release/less_slow                                     # Run the benchmarks
 ```


### PR DESCRIPTION
Currently, on Linux (Ubuntu), the default commands for configuring and building the project result in the `RelWithDebInfo`  build type, even when the intention is to build with `Release` settings. The issue arises when running:

```bash
cmake -B ./build_release
cmake --build ./build_release --config Release
```

Upon inspecting the build directory, the build type is incorrectly set as `RelWithDebInfo`:

```bash
cmake -L ./build_release/ | grep CMAKE_BUILD_TYPE
>>> CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
```

On Linux, the `--config Release` option in the build command does not have the intended effect since it is only relevant for multi-configuration generators (e.g., Xcode, Visual Studio). I believe dependencies rewrite default flag and this behavior results in the `RelWithDebInfo` flags being used (`-O2 -g`), rather than the `Release` flags (`-O3 -DNDEBUG`).

### **Proposed Fix**
The issue can be resolved by explicitly specifying the `-DCMAKE_BUILD_TYPE=Release` flag during configuration. For example:

```bash
cmake -B ./build_release -DCMAKE_BUILD_TYPE=Release
cmake --build ./build_release --config Release
```