### PR TITLE
Fix deps

### DIFF
--- a/less_slow.cpp
+++ b/less_slow.cpp
@@ -3242,6 +3242,7 @@ struct log_printf_t {
     }
 };
 
+#if defined(__cpp_lib_format)
 #include <format> // `std::format_to_n`
 
 struct log_format_t {
@@ -3273,6 +3274,8 @@ struct log_format_t {
         return static_cast<std::size_t>(result.size);
     }
 };
+
+#endif // defined(__cpp_lib_format)
 
 #include <fmt/chrono.h>  // formatting for `std::chrono` types
 #include <fmt/compile.h> // compile-time format strings
@@ -3333,7 +3336,9 @@ static void logging(bm::State &state) {
 }
 
 BENCHMARK(logging<log_printf_t>)->Name("log_printf")->MinTime(2);
+#if defined(__cpp_lib_format)
 BENCHMARK(logging<log_format_t>)->Name("log_format")->MinTime(2);
+#endif
 BENCHMARK(logging<log_fmt_t>)->Name("log_fmt")->MinTime(2);
 
 /**


### PR DESCRIPTION
Add `std::format` only if GCC supports it